### PR TITLE
:art: Moar appealing contacts, end "surprise links"

### DIFF
--- a/components/ContactInformation.tsx
+++ b/components/ContactInformation.tsx
@@ -27,14 +27,14 @@ export default function ContactInformation({ locale }: { locale: Locale }) {
       href: CONTACT_INFO.linkedin,
       icon: "/linkedin.png",
       alt: translations.contact.linkedin,
-      text: "LinkedIn",
+      text: "/in/liza-blomdahl",
       isExternal: true,
     },
     {
       href: CONTACT_INFO.github,
       icon: "/github.png",
       alt: translations.contact.github,
-      text: "GitHub",
+      text: "@okaziya",
       isExternal: true,
     },
   ];


### PR DESCRIPTION
Me, personally, I do not like "surprise links" a lot, i.e. having to hover or inspect link to see where I'm taken when clicking on something. Same as you'd write the ["0730-567 567"](https://localhost:1337) instead of ["Call me"](https://localhost:1337), ["liza.blomdahl@gmail.com"](https://localhost:1337) instead of ["Email me"](https://localhost:1337); I think it's appropriate and self-explanatory to write ["@okaziya"](https://localhost:1337) instead of ["GitHub"](https://localhost:1337) and so on. 🙃

Here's how it would look as a baseline from #12:
<img width="880" alt="image" src="https://github.com/user-attachments/assets/6eef92c9-79c9-41e5-8539-07697c560459" />

I think it should be changed to a more appealing presentation of contact info:
<img width="894" alt="image" src="https://github.com/user-attachments/assets/a16b6870-7a8e-432f-bcb8-80134a984eab" />
