### PR TITLE
More PDF-export comments for #41

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ npm run dev
 
 Format the code correctly with Prettier before submitting a PR, `npm run format`.
 
+**Note:** For playing with the PDF export feature, you may enable a live preview by uncommenting
+the _`PDFViewer`_ component in `app/[locale]/page.tsx`.
+
 ## Contributing
 
 Do You have some good ideas on how to make your CV into a website? A site that can serve as

--- a/components/CvDocument.tsx
+++ b/components/CvDocument.tsx
@@ -268,7 +268,7 @@ const CvDocument = () => (
 
           {/* Skills */}
           <View style={styles.section}>
-            <Text style={styles.title}>Skills</Text>
+            <Text style={styles.title}>Teknologier/färdigheter</Text>
             <Text style={styles.skills}>
               TypeScript, JavaScript, Python, HTML5, CSS3, SQL, React, Agile, Scrum, Bootstrap, SASS, Material UI,
               GraphQL, Next.js, tRPC, useQuery, REST API, CI/CD (GitHub Actions, CircleCI), MongoDB, DynamoDB, SQLite,

--- a/components/CvDocument.tsx
+++ b/components/CvDocument.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Page, Text, View, Document, StyleSheet, Font, Image } from "@react-pdf/renderer";
+import { Page, Link, Text, View, Document, StyleSheet, Font, Image } from "@react-pdf/renderer";
 
 Font.register({
   family: "Nunito Sans",
@@ -213,7 +213,9 @@ const CvDocument = () => (
             <Text>EU-medborgare (Tjeckien), svenskt personnummer: 940711-4223</Text>
             <Text style={styles.personalNumber}></Text>
           </View>
-          <Text style={styles.organizationName}>https://okaziya.github.io/cv/</Text>
+          <Text style={styles.organizationName}>
+            <Link src="https://okaziya.github.io/cv/">https://okaziya.github.io/cv/</Link>
+          </Text>
         </View>
 
         {/* Main Content */}
@@ -233,24 +235,34 @@ const CvDocument = () => (
             <Text style={styles.title}>Kontakt</Text>
             <View style={styles.contactRow}>
               <Image style={styles.contactIcon} src="city.png" />
-              <Text style={styles.contactText}>Stockholm</Text>
+              <Text style={styles.contactText}>
+                &nbsp;<Link src="https://maps.app.goo.gl/svMdqrQLshZExFHJ8">Hjorthagen, Stockholm</Link>
+              </Text>
             </View>
             <View style={styles.contactRow}>
               <Image style={styles.contactIcon} src="phone-gray.png" />
-              <Text style={styles.contactText}> 0730-500 244</Text>
+              <Text style={styles.contactText}>
+                &nbsp;<Link src="tel:+46730500244">0730-500 244</Link>
+              </Text>
             </View>
             <View style={styles.contactRow}>
               <Image style={styles.contactIcon} src="email-gray.png" />
-              <Text style={styles.contactText}> liza.blomdahl@gmail.com</Text>
+              <Text style={styles.contactText}>
+                &nbsp;<Link src="mailto:liza@owntube.tv">liza@owntube.tv</Link>
+              </Text>
             </View>
 
             <View style={styles.contactRow}>
               <Image style={styles.contactIcon} src="in-gray.png" />
-              <Text style={styles.contactText}> linkedin.com/in/liza-blomdahl/</Text>
+              <Text style={styles.contactText}>
+                &nbsp;<Link src="https://www.linkedin.com/in/liza-blomdahl/">linkedin.com/in/liza-blomdahl/</Link>
+              </Text>
             </View>
             <View style={styles.contactRow}>
               <Image style={styles.contactIcon} src="github-gray.png" />
-              <Text style={styles.contactText}> @okaziya</Text>
+              <Text style={styles.contactText}>
+                &nbsp;<Link src="https://github.com/okaziya">@okaziya</Link>
+              </Text>
             </View>
           </View>
 

--- a/components/CvDocument.tsx
+++ b/components/CvDocument.tsx
@@ -318,7 +318,7 @@ const CvDocument = () => (
           <View style={styles.section}>
             <Text style={styles.title}>Språk</Text>
             <Text style={styles.languageRow}>Svenska – Mellannivå (på väg mot B2)</Text>
-            <Text style={styles.languageRow}>Engelska - Övre medelnivå (B2)</Text>
+            <Text style={styles.languageRow}>Engelska – Övre medelnivå (B2)</Text>
             <Text style={styles.languageRow}>Tjeckiska – Flytande (C2)</Text>
             <Text style={styles.languageRow}>Ryska – Flytande (C2)</Text>
           </View>
@@ -352,7 +352,7 @@ const CvDocument = () => (
               <View style={styles.listItem}>
                 <Text style={styles.bullet}>•</Text>
                 <Text style={styles.itemContent}>
-                  Byggt ett antal projekt med olika AI-verktyg: Lovable.dev-appar, egna CustomGPTs i ChatGPT och OpenAI
+                  Byggt ett antal projekt med olika AI-verktyg: Lovable.dev- appar, egna CustomGPTs i ChatGPT och OpenAI
                   Assistants.
                 </Text>
               </View>

--- a/components/CvDocument.tsx
+++ b/components/CvDocument.tsx
@@ -387,13 +387,8 @@ const CvDocument = () => (
               <View style={styles.listItem}>
                 <Text style={styles.bullet}>•</Text>
                 <Text style={styles.itemContent}>
-                  Bidrog till utvecklingen av en klientportal för forex, liknande en internetbank.
-                </Text>
-              </View>
-              <View style={styles.listItem}>
-                <Text style={styles.bullet}>•</Text>
-                <Text style={styles.itemContent}>
-                  Fokuserade på att förbättra portalens funktioner genom migrering från GraphQL till tRPC.
+                  Bidrog till utvecklingen av en klientportal för forex, liknande en internetbank, och förbättrade
+                  portalens funktion genom migrering från GraphQL till tRPC.
                 </Text>
               </View>
             </View>

--- a/config.ts
+++ b/config.ts
@@ -1,6 +1,6 @@
 export const CONTACT_INFO = {
   name: "Liza Blomdahl",
-  email: "liza.blomdahl@gmail.com",
+  email: "liza@owntube.tv",
   phone: "0730-500 244",
   linkedin: "https://www.linkedin.com/in/liza-blomdahl/",
   github: "https://github.com/okaziya",


### PR DESCRIPTION
Here's a few ideas for additional improvements on #41!

## Visual comparison of exports

<img width="1420" alt="image" src="https://github.com/user-attachments/assets/b7ec4f91-2bf0-46ef-a007-ef922b377434" />



## Ideas

### Idea 1: README hint on where to enable PDF preview

Addition to c15ef75e


### Idea 2: Replace private email with work email, consistently


### Idea 3: Use Links! It's not like many people are going to re-share it on a physical paper. :)

But @okaziya maybe can fix color + remove underline with styling? And use something smarter than `&nbsp;` for spacing. :)


### Idea 4: Use Swedish wording for "Skills", "Teknologier/färdigheter"?


### Idea 5: Rendering details, correct em-dash + line breaking


### Idea 6: Consolidate highlights from forex experience

Having these two as separate highlights feels a bit weak:
1. Bidrog till utvecklingen av en klientportal för forex, liknande en internetbank.
2. Fokuserade på att förbättra portalens funktioner genom migrering från GraphQL till tRPC.

I would rather want to consolidate it into 1 bullet:

- Bidrog till utvecklingen av en klientportal för forex, liknande en internetbank, och förbättrade portalens funktion genom migrering från GraphQL till tRPC.