### PR TITLE
CV: Swedish to C1 (SVA) and refreshed OwnTube role

### DIFF
--- a/components/CvDocument.tsx
+++ b/components/CvDocument.tsx
@@ -337,28 +337,35 @@ const CvDocument = () => (
             <Text style={styles.title}>Anställningar</Text>
             <View>
               <View style={styles.row}>
-                <Text style={styles.subtitle}>Medgrundare & IT-konsult</Text>
+                <Text style={styles.subtitle}>Grundare & Fullstackutvecklare</Text>
                 <Text style={styles.year}>(2024-10–pågående)</Text>
               </View>
               <Text style={styles.organizationName}>OwnTube Nordic AB – Stockholm, Sverige </Text>
+              {/*<View style={styles.listItem}>*/}
+              {/*  <Text style={styles.bullet}>•</Text>*/}
+              {/*  <Text style={styles.itemContent}>*/}
+              {/*    Grundade OwnTube Nordic AB, ett IT-konsultbolag med fokus på modern mjukvara och AI-teknologi.*/}
+              {/*  </Text>*/}
+              {/*</View>*/}
+              {/*<View style={styles.listItem}>*/}
+              {/*  <Text style={styles.bullet}>•</Text>*/}
+              {/*  <Text style={styles.itemContent}>*/}
+              {/*    Integration i Sverige: lärde mig om arbetsmarknad/företagskultur i mitt nya hemland, lärde mig*/}
+              {/*    språket, och etablerade ett professionellt nätverk i Stockholm.*/}
+              {/*  </Text>*/}
+              {/*</View>*/}
               <View style={styles.listItem}>
                 <Text style={styles.bullet}>•</Text>
                 <Text style={styles.itemContent}>
-                  Medgrundade konsultbolaget OwnTube Nordic AB tillsammans med min partner.
-                </Text>
-              </View>
-              <View style={styles.listItem}>
-                <Text style={styles.bullet}>•</Text>
-                <Text style={styles.itemContent}>
-                  Integration i Sverige: folkbokföring avklarad, kontakt med myndigheter och banker, slutfört alla steg
-                  i SFI och lärt mig om arbetsmarknad/företagskultur i mitt nya hemland.
-                </Text>
-              </View>
-              <View style={styles.listItem}>
-                <Text style={styles.bullet}>•</Text>
-                <Text style={styles.itemContent}>
-                  Byggt ett antal projekt med olika AI-verktyg: Lovable.dev- appar, egna CustomGPTs i ChatGPT och OpenAI
+                  Byggde flera kundprojekt med AI-verktyg: Lovable.dev- appar, egna CustomGPTs i ChatGPT och OpenAI
                   Assistants.
+                </Text>
+              </View>
+              <View style={styles.listItem}>
+                <Text style={styles.bullet}>•</Text>
+                <Text style={styles.itemContent}>
+                  Ledde community-engagement och utveckling av open source-projektet OwnTube.tv. Koordinerade krav med
+                  leverantörer och utvecklade mjukvarukomponenter till ekosystemet omkring videoplattformen.
                 </Text>
               </View>
             </View>

--- a/components/CvDocument.tsx
+++ b/components/CvDocument.tsx
@@ -285,10 +285,10 @@ const CvDocument = () => (
             <Text style={styles.title}>Utbildning</Text>
             <View style={styles.section}>
               <View style={styles.row}>
-                <Text style={styles.subtitle}>Svenska A1 till B2</Text>
-                <Text style={styles.year}>(2024-2025)</Text>
+                <Text style={styles.subtitle}>Svenska (SVA) nivå 3</Text>
+                <Text style={styles.year}>(2025–2026)</Text>
               </View>
-              <Text style={styles.organizationName}>Folkuniversitetet – Stockholm</Text>
+              <Text style={styles.organizationName}>Komvux – Stockholm, Sverige</Text>
             </View>
 
             <View style={styles.section}>
@@ -324,7 +324,7 @@ const CvDocument = () => (
           {/* Languages */}
           <View style={styles.section}>
             <Text style={styles.title}>Språk</Text>
-            <Text style={styles.languageRow}>Svenska – Övre medelnivå (B2)</Text>
+            <Text style={styles.languageRow}>Svenska – Avancerad (C1)</Text>
             <Text style={styles.languageRow}>Engelska – Avancerad (C1)</Text>
             <Text style={styles.languageRow}>Tjeckiska – Flytande (C2)</Text>
           </View>

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -284,6 +284,17 @@ const en = {
   education: {
     title: "Education",
     degrees: [
+      {
+        jobTitle: "Swedish as a Second Language 1, 2 & 3",
+        companyTitle: "Komvux – Stockholm, Sweden",
+        date: "2025–2026",
+        highlights:
+          "- Completed the upper-secondary courses Swedish as a Second Language 1, 2 and 3.\n" +
+          "- Reached advanced proficiency in Swedish (CEFR C1) and eligibility for university/higher education in Sweden.\n",
+        description: null,
+        assignmentsText: null,
+        internalProjectNotes: null,
+      },
       // {
       //   jobTitle: "Swedish for programmers",
       //   companyTitle: "SFX-IT – Tyresö, Sweden",
@@ -294,17 +305,15 @@ const en = {
       //   assignmentsText: null,
       //   internalProjectNotes: null,
       // },
-      {
-        jobTitle: "Swedish courses A1 to B2",
-        companyTitle: "Folkuniversitetet – Stockholm, Sweden",
-        date: "2024–2025",
-        highlights:
-          "- Completed first 5 Swedish courses in 6 months of half-time classroom studies.\n" +
-          "- Reached intermediate proficiency in Swedish, CEFR level B1.\n",
-        description: null,
-        assignmentsText: null,
-        internalProjectNotes: null,
-      },
+      // {
+      //   jobTitle: "Swedish courses A1 to B2",
+      //   companyTitle: "Folkuniversitetet – Stockholm, Sweden",
+      //   date: "2024–2025",
+      //   highlights: "- Completed first 5 Swedish courses in 6 months of half-time classroom studies.\n",
+      //   description: null,
+      //   assignmentsText: null,
+      //   internalProjectNotes: null,
+      // },
       {
         jobTitle: "BSc in Software Development",
         companyTitle: "Unicorn University – Prague, Czech Republic",
@@ -366,7 +375,7 @@ const en = {
     languages: [
       {
         name: "Swedish",
-        level: "Upper-Intermediate (B2)",
+        level: "Advanced (C1)",
       },
       {
         name: "English",

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -102,17 +102,17 @@ const en = {
     title: "Experience",
     experiences: [
       {
-        jobTitle: "Co-Founder & Consultant",
+        jobTitle: "Founder & Full Stack Developer",
         companyTitle: "OwnTube Nordic AB – Stockholm, Sweden",
         date: "2024-10–Present",
         highlights:
-          "- Co-founded own IT consulting company OwnTube Nordic AB with my partner.\n" +
-          "- Familiarized myself with business context and culture in Sweden, gained proficiency in dealing with " +
-          "Swedish authorities and banks. Learnt Swedish up to intermediate proficiency level and completed Swedish " +
-          "For Immigrants (SFI).\n" +
-          "- Built a number of projects using different AI tools; Lovable.dev apps, CustomGPTs in ChatGPT, OpenAI " +
-          "Assistants. Established professional network in Stockholm; meeting with customers and building " +
-          "partnerships.\n",
+          "- Founded OwnTube Nordic AB, an IT consulting company focused on modern software and AI technology.\n" +
+          "- Gained familiarity with culture, society and business context in Sweden. Learnt Swedish and established " +
+          "professional network in Stockholm.\n" +
+          "- Built multiple customer projects using AI tools; Lovable.dev apps, CustomGPTs in ChatGPT, OpenAI " +
+          "Assistants.\n" +
+          "- Led community engagement and development for the OwnTube.tv open-source project (a PeerTube client " +
+          "based on React Native). Coordinated requirements with vendors and developed supporting components.\n",
         description: null,
         assignmentsText: null,
         internalProjectNotes: {
@@ -139,6 +139,13 @@ const en = {
             "Learning Swedish IT vocabulary\n" +
             "Professional skills in Swedish\n" +
             "Getting all documents in place, translated Czech grades and more\n" +
+            "...\n",
+          // 2025-09 to 2026-06
+          Komvux:
+            "Svenska som andraspråk 1, 2, and 3\n" +
+            "Företagsekonomi 1\n" +
+            "Driver's license\n" +
+            "Engelska 1 and 2\n" +
             "...\n",
         },
       },

--- a/locales/sv.ts
+++ b/locales/sv.ts
@@ -102,16 +102,18 @@ const sv = {
     title: "Erfarenhet",
     experiences: [
       {
-        jobTitle: "Medgrundare & IT-konsult",
+        jobTitle: "Grundare & Fullstackutvecklare",
         companyTitle: "OwnTube Nordic AB – Stockholm, Sverige",
         date: "2024-10–pågående",
         highlights:
-          "- Medgrundade konsultbolaget OwnTube Nordic AB tillsammans med min partner.\n" +
-          "- Integration i Sverige: folkbokföring avklarad, kontakt med myndigheter och banker, slutfört alla steg i " +
-          "SFI och lärt mig om arbetsmarknad/företagskultur i mitt nya hemland.\n" +
-          "- Byggt ett antal projekt med olika AI-verktyg: Lovable.dev-appar, egna CustomGPTs i ChatGPT och OpenAI " +
+          "- Grundade OwnTube Nordic AB, ett IT-konsultbolag med fokus på modern mjukvara och AI-teknologi.\n" +
+          "- Integration i Sverige: lärde mig om arbetsmarknad/företagskultur i mitt nya hemland, lärde mig språket, " +
+          "och etablerade ett professionellt nätverk i Stockholm.\n" +
+          "- Byggde flera kundprojekt med AI-verktyg: Lovable.dev-appar, egna CustomGPTs i ChatGPT och OpenAI " +
           "Assistants.\n" +
-          "- Etablerat professionellt nätverk i Stockholm, träffat kunder och påbörjat yrkesmässiga samarbeten.\n",
+          "- Ledde community-engagement och utveckling av open source-projektet OwnTube.tv (en PeerTube-klient " +
+          "baserad på React Native). Koordinerade kravställning med leverantörer och utvecklade mjukvarukomponenter " +
+          "till ekosystemet kring videoplattformen.\n",
         description: null,
         assignmentsText: null,
         internalProjectNotes: null,

--- a/locales/sv.ts
+++ b/locales/sv.ts
@@ -327,6 +327,17 @@ const sv = {
   education: {
     title: "Utbildning",
     degrees: [
+      {
+        jobTitle: "Svenska som andraspråk 1, 2 och 3",
+        companyTitle: "Komvux – Stockholm, Sverige",
+        date: "2025–2026",
+        highlights:
+          "- Slutförde gymnasiekurserna Svenska som andraspråk 1, 2 och 3.\n" +
+          "- Uppnådde avancerad nivå i svenska (CEFR C1) och behörighet till högskola/universitet i Sverige.\n",
+        description: null,
+        assignmentsText: null,
+        internalProjectNotes: null,
+      },
       // {
       //   jobTitle: "Svenska för programmerare",
       //   companyTitle: "SFX-IT – Tyresö, Sverige",
@@ -337,15 +348,15 @@ const sv = {
       //   assignmentsText: null,
       //   internalProjectNotes: null,
       // },
-      {
-        jobTitle: "Svenska A1 till B2",
-        companyTitle: "Folkuniversitetet – Stockholm, Sverige",
-        date: "2024–2025",
-        highlights: "- Slutförde första 5 svenska-kurserna (6 månader av klassrumsstudier på halvfart).\n",
-        description: null,
-        assignmentsText: null,
-        internalProjectNotes: null,
-      },
+      // {
+      //   jobTitle: "Svenska A1 till B2",
+      //   companyTitle: "Folkuniversitetet – Stockholm, Sverige",
+      //   date: "2024–2025",
+      //   highlights: "- Slutförde första 5 svenska-kurserna (6 månader av klassrumsstudier på halvfart).\n",
+      //   description: null,
+      //   assignmentsText: null,
+      //   internalProjectNotes: null,
+      // },
       {
         jobTitle: "BSc in Software Development",
         companyTitle: "Unicorn University – Prag, Tjeckien",
@@ -420,7 +431,7 @@ const sv = {
     languages: [
       {
         name: "Svenska",
-        level: "Övre medelnivå (B2)",
+        level: "Avancerad (C1)",
       },
       {
         name: "Engelska",


### PR DESCRIPTION
## Summary

Two CV content updates, verified to render correctly into both the site (SSR HTML + JSON-LD) and the downloadable PDF.

## Changes

- **Swedish → C1 (Svenska som andraspråk 1–3):** Add a Komvux education entry (2025–2026) for completing Svenska som andraspråk 1, 2 and 3, and raise Swedish proficiency from B2 to C1 (Advanced) across both locales and the PDF. The earlier Folkuniversitet A1–B2 course is commented out in the locales and dropped from the PDF so only the highest level shows; in the sidebar-constrained PDF the entry is labelled "Svenska (SVA) nivå 3". Education locations now read "Stockholm, Sverige" consistently.
- **OwnTube Nordic role refresh:** Retitle the current role to Founder & Full Stack Developer, drop the now-outdated "intermediate proficiency" Swedish note (superseded by the C1 entry), and add the OwnTube.tv open-source community and development work.

## Verification

- `npm run build` ✅ (types + lint), `npm run format:check` ✅
- JSON-LD reflects the changes: `alumniOf` includes Komvux and no longer Folkuniversitetet; the content is present in the server-rendered `out/en.html` / `out/sv.html` (readable without JavaScript).
- PDF line-fit checked (the sidebar entry fits on one line); the visual PDF layout was reviewed manually.

## Follow-up (separate PR)

A docs note on the SSR/JSON-LD invariant plus automated tests asserting the expected strings in the JSON-LD and compiled output — with the visual review kept manual.
