### PR TITLE
Sync sv.ts tech lists with the PDF export (closes #58)

### DIFF
--- a/locales/en.ts
+++ b/locales/en.ts
@@ -85,6 +85,7 @@ const en = {
           "Amazon S3",
           "Jekyll",
           "Next.js",
+          "Vercel",
           "Storybook",
           "Tailwind CSS",
           "Git & GitHub",

--- a/locales/sv.ts
+++ b/locales/sv.ts
@@ -85,6 +85,7 @@ const sv = {
           "Amazon S3",
           "Jekyll",
           "Next.js",
+          "Vercel",
           "Storybook",
           "Tailwind CSS",
           "Git & GitHub",
@@ -173,8 +174,8 @@ const sv = {
           "slutet av uppdraget utvecklade hon även ett internt verktyg för att ställa databasfrågor kring " +
           "kundbeteenden och compliance.\n" +
           "\n" +
-          "**TEKNOLOGIER:** React, TypeScript, Styled Components, Apollo GraphQL, tRPC, Postico, MongoDB, AWS " +
-          "Lambda, AWS AppConfig, Git Monorepo, Figma, Linear, GitHub, Slack, VS Code, GitHub Actions\n" +
+          "**TEKNOLOGIER:** React, TypeScript, Zod, Yup, Styled Components, Apollo GraphQL, tRPC, Postico, MongoDB, " +
+          "AWS Lambda, AWS AppConfig, Git Monorepo, Figma, Linear, GitHub, Slack, VS Code, GitHub Actions\n" +
           "\n" +
           "**NYCKELORD:** FinTech, forex/FX, trading-plattform, användarhantering, UX, compliance, bank och finans, " +
           "autentisering & auktorisation, Reusable Components, AWS, CI/CD, Serverless, Agile, " +
@@ -193,9 +194,9 @@ const sv = {
           "prestanda och arbeta med datakvalitet. Ett av Lizas varmaste minnen från den här tiden är ett initiativ " +
           "för att tillhandahålla compliance-teamet med ett rapporteringsverktyg för beslutsstöd kring insättningar." +
           "\n\n" +
-          "**TEKNOLOGIER:** React, TypeScript, Next.js, AWS S3, AWS Cognito, AWS Lambda, MongoDB Atlas, Postgres, " +
-          "SQL, Apollo GraphQL, tRPC, AtlasSearch, Jest, Git Monorepo, Figma, Jira, Linear, GitHub, Slack, VS Code, " +
-          "CircleCI\n" +
+          "**TEKNOLOGIER:** React, TypeScript, Zod, Next.js, AWS S3, AWS Cognito, AWS Lambda, MongoDB Atlas, " +
+          "Postgres, SQL, Apollo GraphQL, tRPC, AtlasSearch, Jest, Git Monorepo, Figma, Jira, Linear, GitHub, Slack, " +
+          "VS Code, CircleCI\n" +
           "\n" +
           "**NYCKELORD:** CRM, FinTech, query-optimering, UX, compliance, prestandatestning, lösningsarkitektur, " +
           "datamodellering, datakvalitet, databas-design, CI/CD, Serverless, Agile\n" +
@@ -250,8 +251,8 @@ const sv = {
           "frontend, backend och autentiseringslösning. React/Bootstrap för frontend, Firebase för backend, " +
           "Firestore/Realtime Database för datapersistens, och Google SSO för autentisering.\n" +
           "\n" +
-          "**TEKNOLOGIER:** React, Bootstrap, SASS, Firebase Realtime Database, Firebase Firestore, Google Single " +
-          "Sign-On, GitHub, WebStorm, Slack\n" +
+          "**TEKNOLOGIER:** React, Bootstrap, SASS, Firebase Realtime Database, Vercel, Firebase Firestore, " +
+          "Google Single Sign-On, GitHub, WebStorm, Slack\n" +
           "\n" +
           "**NYCKELORD:** Admin-panel, Firebase, administrationsverktyg\n" +
           "\n" +


### PR DESCRIPTION
## Summary

Resolves the drift reported in #58: the hand-maintained PDF export (`components/CvDocument.tsx`) listed technologies that were missing from `locales/sv.ts` — the source of truth for the web page's assignment history and the JSON-LD. Per the issue's chosen direction, the fix **adds** the technologies to `sv.ts` (rather than removing them from the PDF), so the web, JSON-LD and PDF all say the same thing.

## Changes

- **`assignmentsText` (sv.ts):** added `Zod, Yup` to the Axiory assignment, `Zod` to the CRM assignment, and `Vercel` to the admin-panel assignment — matching what the PDF already showed.
- **Skills (tools):** added `Vercel` to the "Verktyg och ramverk" / "Tools & Frameworks" category in both `sv.ts` and `en.ts`, so it appears in the JSON-LD `knowsAbout` and the two locales stay parallel.

## Verification

- `npm run build` ✅, `npm run format:check` ✅
- JSON-LD now includes `Vercel` in `knowsAbout` for both locales, and `Zod`/`Yup` in the Swedish `memberOf` assignment descriptions — the PDF, web and structured data are now consistent.

Closes #58
